### PR TITLE
Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,11 @@ RUST_BIN = ./bin/wc-rust
 HASKELL_SRC = ./wc-haskell/src/Lib.hs ./wc-haskell/app/Main.hs
 HASKELL_BIN = ./bin/wc-haskell
 
+PYTHON_SRC = ./wc-python/src/wc.py
+PYTHON_BIN = ./bin/wc-python
+
 .PHONY: all
-all: go haskell rust
+all: go haskell rust python
 
 .PHONY: rust
 go: $(GO_BIN)
@@ -32,3 +35,9 @@ $(RUST_BIN): $(RUST_SRC)
 	cargo build --release && \
 	cd ../ && \
 	cp $(RUST_SRC_DIR)target/release/wc-rust $(RUST_BIN)
+
+.PHONY: python
+python: $(PYTHON_BIN)
+
+$(PYTHON_BIN): $(PYTHON_SRC)
+	cp $(PYTHON_SRC) $(PYTHON_BIN) && chmod u+x $(PYTHON_BIN)

--- a/wc-python/src/wc.py
+++ b/wc-python/src/wc.py
@@ -28,17 +28,8 @@ def main():
         paths = [os.path.join(dirname, f) for f in os.listdir(dirname)]
     filenames = [p for p in paths if os.path.isfile(p)]
     counts = {}
-    # Fun fact: you can replace 'Process' with 'Thread' below and python will
-    # use threads without any fuss (the API is the same). I've found that
-    # for small directories and files, threads are faster, but once the number
-    # and size of files gets large enough, processes become faster. Running
-    # this program on my ~/Documents dir (50 files, 214k lines) takes ~0.260s 
-    # with threads and ~1.384s with processes. However, on my ~/Downloads
-    # directory (198 files and 14m lines), threads take around 7 seconds and
-    # processes take about 3. Threads are quicker to start up, and so are
-    # better for small tasks, but processes catch up when they can take full
-    # full advantage of multiple cores.
-    with futures.ThreadPoolExecutor(max_workers=len(filenames)) as executor:
+    # with futures.ThreadPoolExecutor(max_workers=len(filenames)) as executor:
+    with futures.ProcessPoolExecutor(max_workers=len(filenames)) as executor:
         all_futures = [executor.submit(line_count, f) for f in filenames]
         for future in futures.as_completed(all_futures):
             filename, count = future.result()

--- a/wc-python/src/wc.py
+++ b/wc-python/src/wc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Emulates wc -l using concurrent processes/threads."""
 
 import sys
@@ -8,21 +8,22 @@ from concurrent import futures
 
 def count_lines(filename):
     """Open file, count newlines, then return (filename, line_count) tuple."""
-    with open(filename, 'r') as file_to_read:
-        lines = file_to_read.readlines()
-        line_count = len(lines)
-        # Because readlines() returns a line even if the only
-        # text in the file is not terminated by a newline
-        if line_count == 1:
-            if '\n' not in lines[0]:
-                line_count = 0
+    with open(filename, 'rb') as file_to_read:
+        chunk_size = 8192
+        line_count = 0
+        while True:
+            chunk = file_to_read.read(chunk_size)
+            if chunk:
+                line_count += chunk.count(b'\n')
+            else:
+                break
         return filename, line_count
 
 
 def print_count(count, label):
     """Print a line count right-justified along with a label."""
     formatted_count = str(count).rjust(10)
-    print "{} {}".format(formatted_count, label)
+    print("{} {}".format(formatted_count, label))
 
 
 def main():

--- a/wc-python/src/wc.py
+++ b/wc-python/src/wc.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
+"""Emulates wc -l using concurrent processes/threads."""
 
 import sys
 import os
 from concurrent import futures
 
-def line_count(filename):
-    with open(filename, 'r') as f:
-        lines = f.readlines()
+
+def count_lines(filename):
+    """Open file, count newlines, then return (filename, line_count) tuple."""
+    with open(filename, 'r') as file_to_read:
+        lines = file_to_read.readlines()
         line_count = len(lines)
         # Because readlines() returns a line even if the only
         # text in the file is not terminated by a newline
@@ -15,11 +18,17 @@ def line_count(filename):
                 line_count = 0
         return filename, line_count
 
+
 def print_count(count, label):
+    """Print a line count right-justified along with a label."""
     formatted_count = str(count).rjust(10)
     print "{} {}".format(formatted_count, label)
 
+
 def main():
+    """Takes directory as argument, returns number of newlines in all files in
+    the that directory (non-recursively).
+    """
     if len(sys.argv) < 2:
         dirname = '.'
         paths = [f for f in os.listdir(dirname)]
@@ -30,14 +39,15 @@ def main():
     counts = {}
     # with futures.ThreadPoolExecutor(max_workers=len(filenames)) as executor:
     with futures.ProcessPoolExecutor(max_workers=len(filenames)) as executor:
-        all_futures = [executor.submit(line_count, f) for f in filenames]
+        all_futures = [executor.submit(count_lines, f) for f in filenames]
         for future in futures.as_completed(all_futures):
             filename, count = future.result()
             counts[filename] = count
-    ranked = sorted(counts, key=lambda k:-counts[k])
+    ranked = sorted(counts, key=lambda k: -counts[k])
     for filename in ranked:
         print_count(counts[filename], filename)
     print_count(sum(counts.values()), "[TOTAL]")
+
 
 if __name__ == "__main__":
     main()

--- a/wc-python/src/wc.py
+++ b/wc-python/src/wc.py
@@ -32,13 +32,13 @@ def main():
     # use threads without any fuss (the API is the same). I've found that
     # for small directories and files, threads are faster, but once the number
     # and size of files gets large enough, processes become faster. Running
-    # this program on the root repo directory (4 small files) takes ~0.127s 
-    # with threads and ~0.205s with processes. However, on my ~/Downloads
-    # directory (198 files and 14m lines), threads take around 7 seconds and 
+    # this program on my ~/Documents dir (50 files, 214k lines) takes ~0.260s 
+    # with threads and ~1.384s with processes. However, on my ~/Downloads
+    # directory (198 files and 14m lines), threads take around 7 seconds and
     # processes take about 3. Threads are quicker to start up, and so are
     # better for small tasks, but processes catch up when they can take full
     # full advantage of multiple cores.
-    with futures.ProcessPoolExecutor(max_workers=len(filenames)) as executor:
+    with futures.ThreadPoolExecutor(max_workers=len(filenames)) as executor:
         all_futures = [executor.submit(line_count, f) for f in filenames]
         for future in futures.as_completed(all_futures):
             filename, count = future.result()

--- a/wc-python/src/wc.py
+++ b/wc-python/src/wc.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+import sys
+import os
+from concurrent import futures
+
+def line_count(filename):
+    with open(filename, 'r') as f:
+        lines = f.readlines()
+        line_count = len(lines)
+        # Because readlines() returns a line even if the only
+        # text in the file is not terminated by a newline
+        if line_count == 1:
+            if '\n' not in lines[0]:
+                line_count = 0
+        return filename, line_count
+
+def print_count(count, label):
+    formatted_count = str(count).rjust(10)
+    print "{} {}".format(formatted_count, label)
+
+def main():
+    if len(sys.argv) < 2:
+        dirname = '.'
+        paths = [f for f in os.listdir(dirname)]
+    else:
+        dirname = os.path.abspath(sys.argv[1])
+        paths = [os.path.join(dirname, f) for f in os.listdir(dirname)]
+    filenames = [p for p in paths if os.path.isfile(p)]
+    counts = {}
+    # Fun fact: you can replace 'Process' with 'Thread' below and python will
+    # use threads without any fuss (the API is the same). I've found that
+    # for small directories and files, threads are faster, but once the number
+    # and size of files gets large enough, processes become faster. Running
+    # this program on the root repo directory (4 small files) takes ~0.127s 
+    # with threads and ~0.205s with processes. However, on my ~/Downloads
+    # directory (198 files and 14m lines), threads take around 7 seconds and 
+    # processes take about 3. Threads are quicker to start up, and so are
+    # better for small tasks, but processes catch up when they can take full
+    # full advantage of multiple cores.
+    with futures.ProcessPoolExecutor(max_workers=len(filenames)) as executor:
+        all_futures = [executor.submit(line_count, f) for f in filenames]
+        for future in futures.as_completed(all_futures):
+            filename, count = future.result()
+            counts[filename] = count
+    ranked = sorted(counts, key=lambda k:-counts[k])
+    for filename in ranked:
+        print_count(counts[filename], filename)
+    print_count(sum(counts.values()), "[TOTAL]")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Python 2.7 specifically, I'll need to finagle it a bit to work with 3.

Fun fact: you can replace 'ProcessPoolExecutor' with 'ThreadPoolExecutor' and python will use threads without any fuss (the API is the same). I've found that for small directories and files, threads are faster, but once the number and size of files gets large enough, processes become faster. Running this program on my `~/Documents` dir (50 files, 214k lines) takes ~0.260s with threads and ~1.384s with processes. However, on my `~/Downloads` directory (198 files and 14m lines), threads take around 7 seconds and processes take about 3. Threads are quicker to start up, and so are better for small tasks, but processes catch up when they can take full full advantage of multiple cores.

Also, I wasn't really sure what to do with the Makefile since python isn't compiled. Let me know if you want me to add anything to it.