### PR TITLE
Rust read entire file into memory for speedup.

### DIFF
--- a/wc-rust/src/bin/wc.rs
+++ b/wc-rust/src/bin/wc.rs
@@ -11,9 +11,15 @@ use wc_rust::ThreadPool;
 thread_local!(static NUM_THREADS: usize = 8);
 
 fn count_lines(path: &Path) -> Result<(usize, PathBuf), std::io::Error> {
-    let file = fs::File::open(path)?;
-    let buf_reader = BufReader::new(file);
-    let lines = buf_reader.lines().count();
+    let mut file = fs::File::open(path)?;
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer)?;
+    let mut lines = 0;
+    for c in buffer {
+        if c == 10 {
+            lines += 1;
+        }
+    }
     Ok((lines, path.to_path_buf()))
 }
 


### PR DESCRIPTION
So turns out that the "person who wrote the rust implementation" *did* do a shitty job. 

Pulling the entire file into memory does have some drawbacks, especially on memory constrained systems or for particularly large files, but it is the *fastest* and the go implementation is doing it so...