### PR TITLE
Fixes to wc-c 

### DIFF
--- a/wc-c/src/wc.c
+++ b/wc-c/src/wc.c
@@ -6,9 +6,15 @@
 #include <string.h>
 #include <stdbool.h>
 #include <unistd.h>
+#include <assert.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#ifdef __APPLE__
+#if TARGET_OS_MAC
 #include <sys/syslimits.h>
+#endif /* TARGET_OS_MAC */
+#endif /* __APPLE__ */
 
 #include "libutils.h"
 
@@ -57,7 +63,13 @@ struct paths *list_dir_paths(char *path) {
 
     char p[PATH_MAX];
     while((d = readdir(dir))) {
+      assert(strlen(path) + strlen(d->d_name) + 1 < PATH_MAX);
       strcpy(p, path);
+
+      if (p[strlen(p) - 1] != '/') {
+        strcat(p, "/");
+      }
+
       strcat(p, d->d_name);
 
       memset(&sb, 0, sizeof(struct stat));


### PR DESCRIPTION
Includes:
- conditional OS library include
- better mutex handling to avoid deadlock-ish situation
- improved path string handling (now with some security as well)

I couldn't test the `ifdef` preprocessor guards - would you let me know if they work on your system?